### PR TITLE
update SSH key names to reflect the core layer

### DIFF
--- a/provision-postgresql
+++ b/provision-postgresql
@@ -43,7 +43,7 @@
         - cloud == 'aws'
 
     - name: building {{ application }}_master host group
-      add_host: hostname="{{ item }}" groupname="{{ application }}_master" ansible_ssh_private_key_file="{{ key_path }}/{{ cloud }}-{{ ec2_region }}-{{ application }}-{{ project }}-{{ domain }}-private-key.pem"
+      add_host: hostname="{{ item }}" groupname="{{ application }}_master" ansible_ssh_private_key_file="{{ key_path }}/{{ cloud }}-{{ ec2_region }}-{{ project }}-{{ application }}-{{ domain }}-private-key.pem"
       with_items: "{{ postgresql_master_instances.instances|map(attribute='private_ip_address')|list }}"
       when:
         - cloud == 'aws'
@@ -66,7 +66,7 @@
         - cloud == 'aws'
       
     - name:  building {{ application }}_replica host group
-      add_host: hostname="{{ item }}" groupname="{{ application }}_replica" ansible_ssh_private_key_file="{{ key_path }}/{{ cloud }}-{{ ec2_region }}-{{ application }}-{{ project }}-{{ domain }}-private-key.pem"
+      add_host: hostname="{{ item }}" groupname="{{ application }}_replica" ansible_ssh_private_key_file="{{ key_path }}/{{ cloud }}-{{ ec2_region }}-{{ project }}-{{ application }}-{{ domain }}-private-key.pem"
       with_items: "{{ postgresql_replica_instances.instances|map(attribute='private_ip_address')|list }}"
       when:
         - cloud == 'aws'


### PR DESCRIPTION
The core layer had change that renamed the SSH keys for easier sorting in large numbers. This minor change reflects adherence to that change.