### PR TITLE
multiple replicas

### DIFF
--- a/master-streaming/tasks/main.yml
+++ b/master-streaming/tasks/main.yml
@@ -40,12 +40,15 @@
       line: "wal_level = hot_standby\t\t\t# minimal, archive, or hot_standby"
     notify: restart postgresql
 
+  # max_wal_senders should be four times the total number of replicas 
+  - set_fact: wal_senders={{ groups['postgresql_replica'] | length * 4 }}  
+  
   - name: configure write ahead log senders
     lineinfile:
       dest: "{{ postgresql_config_path }}/postgresql.conf"
       regexp: "^#max_wal_senders"
       backrefs: yes
-      line: "max_wal_senders = 3\t\t# max number of walsender processes"
+      line: "max_wal_senders = {{ wal_senders }} \t\t# max number of walsender processes"
     notify: restart postgresql
 
   - name: configure checkpoint segments

--- a/provision-postgresql
+++ b/provision-postgresql
@@ -39,8 +39,10 @@
       become: true
       
 # do the auto discovery first as we use all the nodes for master/replica configuration
-- name: discovering all {{ application }} nodes
+- name: discovering all postgresql nodes
   hosts: localhost
+  vars_files:
+      - vars/postgresql.yml
   tasks:
     - ec2_remote_facts:
         region: "{{ ec2_region }}"
@@ -61,8 +63,10 @@
         - cloud == 'aws'
         - postgresql_instances.instances|length > 0
 
-- name: discovering all {{ application }}_master nodes
+- name: discovering all postgresql_master nodes
   hosts: localhost
+  vars_files:
+      - vars/postgresql.yml
   tasks:
     - ec2_remote_facts:
         region: "{{ ec2_region }}"
@@ -84,8 +88,10 @@
         - cloud == 'aws'
         - postgresql_master_instances.instances|length > 0
 
-- name: discovering all {{ application }}_replica nodes
+- name: discovering all postgresql_replica nodes
   hosts: localhost
+  vars_files:
+      - vars/postgresql.yml
   tasks:    
     - ec2_remote_facts:
         region: "{{ ec2_region }}"
@@ -108,9 +114,9 @@
         - postgresql_instances.instances|length > 0
       
 - name: install base configuration for {{ application }}
-  hosts: "{{ application }}"
+  hosts: postgresql
   vars_files:
-      - vars/{{ application }}.yml
+      - vars/postgresql.yml
       - "{{ tenant_config_path }}/config/site.yml"
   gather_facts: yes
   roles:
@@ -119,17 +125,17 @@
     - { role: install-packages, package_list: "{{ postgresql_package_list }}" }
     - { role: postgresql }
 
-- hosts: "{{ application }}_master"
+- hosts: postgresql_master
   gather_facts: no
   vars_files:
-    - vars/{{ application }}.yml
+    - vars/postgresql.yml
   roles:
     - { role: master-streaming }
     
-- hosts: "{{ application }}_replica"
+- hosts: postgresql_replica
   gather_facts: no
   vars_files:
-    - vars/{{ application }}.yml
+    - vars/postgresql.yml
   roles:
     - { role: replica-streaming }
 


### PR DESCRIPTION
* enable multiple replicas from blueprint deployment by calculating `max_wal_senders` instead of a fixed value
* remove need to declare application in provisioning command when deploying postgresql